### PR TITLE
Fix snapcraft.yaml indentation

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,12 +1,11 @@
+name: diy-layout-creator
+version: '3.47.0'
+summary: multi platform circuit layout and schematic drawing tool
+description: |
+  DIY Layout Creator (DIYLC in short) is a freeware drawing tool developed with help of the large online community of DIY electronics enthusiasts. It incorporates many ideas that came from people using older versions of the application. The goal is to provide a simple interface and enough power to let the user draw schematics, board/chassis layouts and guitar wiring diagrams quickly and without a steep learning curve. Also, it is buitd around a flexible open source framework that may be used to draw pretty much anything. 
 
-  name: diy-layout-creator
-  version: '3.47.0'
-  summary: multi platform circuit layout and schematic drawing tool
-  description: |
-    DIY Layout Creator (DIYLC in short) is a freeware drawing tool developed with help of the large online community of DIY electronics enthusiasts. It incorporates many ideas that came from people using older versions of the application. The goal is to provide a simple interface and enough power to let the user draw schematics, board/chassis layouts and guitar wiring diagrams quickly and without a steep learning curve. Also, it is buitd around a flexible open source framework that may be used to draw pretty much anything. 
-
-  grade: devel # must be 'stable' to release into candidate/stable channels
-  confinement: devmode # use 'strict' once you have the right plugs and slots
+grade: devel # must be 'stable' to release into candidate/stable channels
+confinement: devmode # use 'strict' once you have the right plugs and slots
 
 apps:
   diylc:


### PR DESCRIPTION
The previous version of the file didn't parse as valid YAML.