### PR TITLE
Use `exec` in run.sh script

### DIFF
--- a/diylc/diylc-swing/run.sh
+++ b/diylc/diylc-swing/run.sh
@@ -1,1 +1,1 @@
-java -Xms512m -Xmx2048m -javaagent:lib/jar-loader.jar -Dorg.diylc.scriptRun=true -Dfile.encoding=UTF-8 -cp diylc.jar:lib org.diylc.DIYLCStarter
+exec java -Xms512m -Xmx2048m -javaagent:lib/jar-loader.jar -Dorg.diylc.scriptRun=true -Dfile.encoding=UTF-8 -cp diylc.jar:lib org.diylc.DIYLCStarter


### PR DESCRIPTION
This way sh will not fork before launching java and it won't leave an sh process floating around.