### PR TITLE
Partial fix to prevent #706

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Ensure that line endings for .sh files always use LF
+*.sh text eol=lf


### PR DESCRIPTION
Add a .gitattributes file that converts `.sh` files to always use LF.