### PR TITLE
fix for 'x' hotkey preventing 'x' input in dialogs

### DIFF
--- a/diylc/diylc-swing/src/main/java/org/diylc/swing/plugins/explorer/ExplorerPlugin.java
+++ b/diylc/diylc-swing/src/main/java/org/diylc/swing/plugins/explorer/ExplorerPlugin.java
@@ -90,7 +90,9 @@ public class ExplorerPlugin implements IPlugIn {
 
       @Override
       public boolean dispatchKeyEvent(KeyEvent e) {
-        if (e.getKeyChar() == 'x' && e.getModifiersEx() == 0
+        if (explorerPane != null
+            && (canvasPanel.hasFocus() || explorerPane.hasFocus())
+            && e.getKeyChar() == 'x' && e.getModifiersEx() == 0
             && ConfigurationManager.getInstance()
                 .readBoolean(ConfigPlugin.PROJECT_EXPLORER, true)) {
           explorerPane.getSearchField().requestFocusInWindow();

--- a/diylc/diylc-swing/src/main/java/org/diylc/swing/plugins/tree/ComponentTree.java
+++ b/diylc/diylc-swing/src/main/java/org/diylc/swing/plugins/tree/ComponentTree.java
@@ -80,12 +80,13 @@ public class ComponentTree implements IPlugIn {
 
       @Override
       public boolean dispatchKeyEvent(KeyEvent e) {
-        if ((canvasPanel.hasFocus() || treePanel.hasFocus())
-            && e.getKeyChar() == 'q'
+        if (treePanel != null
+            && (canvasPanel.hasFocus() || treePanel.hasFocus())
+            && e.getKeyChar() == 'q' && e.getModifiersEx() == 0
             && ConfigurationManager.getInstance()
                 .readString(ConfigPlugin.COMPONENT_BROWSER, ConfigPlugin.SEARCHABLE_TREE)
                 .equals(ConfigPlugin.SEARCHABLE_TREE)) {
-          getTreePanel().getSearchField().requestFocusInWindow();
+          treePanel.getSearchField().requestFocusInWindow();
           return true;
         }
         return false;


### PR DESCRIPTION
I discovered a problem where I couldn't type a lowercase letter 'x' in a component name. This change should fix that. I used the similar logic to the 'q' hotkey, and made the code in those two more similar.

Note this isn't tested, because I haven't figured out the build yet, I hope you don't mind.

Nice useful program, thank you.
John
