### PR TITLE
Update positon names to match switch positions

### DIFF
--- a/diylc/diylc-library/src/main/java/org/diylc/components/electromechanical/MiniToggleSwitch.java
+++ b/diylc/diylc-library/src/main/java/org/diylc/components/electromechanical/MiniToggleSwitch.java
@@ -502,10 +502,17 @@ public class MiniToggleSwitch extends AbstractTransparentComponent<ToggleSwitchT
   }
 
   @Override
-  public String getPositionName(int position) {    
-    if (switchType.name().endsWith("_off") && position == 2)
-      return "OFF";
-    return "ON" + Integer.toString(position + 1);
+  public String getPositionName(int position) {
+    int pos = position;
+    if (switchType.name().endsWith("_off")) {
+      int midPosition = (getPositionCount() - 1) / 2;
+      if (position == midPosition) {
+        return "OFF";
+      } else if (position > midPosition) {
+        --pos;
+      }
+    }
+    return "ON" + Integer.toString(pos + 1);
   }
 
   @DynamicEditableProperty(source = ToggleSwitchPositionPropertyValueSource.class)


### PR DESCRIPTION
There was an issue raised that the label names for mini toggles with an off position had it listed at the end of the position names rather than in the middle to match the ohysical switch positions:
https://github.com/bancika/diy-layout-creator/issues/950

I wanted to help with the software because I enjoy using it and will like to add, this seemed an easy place to start. I'm not entirely sure what the selected position is supposed to do, does it affect the guitar circuit analysis somehow?