### PR TITLE
Fix S1 Switch markers

### DIFF
--- a/diylc/diylc-library/src/main/java/org/diylc/components/guitar/S1Switch.java
+++ b/diylc/diylc-library/src/main/java/org/diylc/components/guitar/S1Switch.java
@@ -208,9 +208,9 @@ public class S1Switch extends AbstractTransparentComponent<Void> implements ISwi
       
       double dy = 0;
       if (i % 3 == 1) {
-        dy = -1;
-      } else if (i % 3 == 0) {
         dy = 1;
+      } else if (i % 3 == 0) {
+        dy = -1;
       }
       
       Stroke stroke = g2d.getStroke();


### PR DESCRIPTION
The marker positions for the S1 Switch appeared to be the wrong way around. I did a diagram for someone involving the S1 switch and they reported that it operated the wrong way around, other diagrams of the switch confirm this:
https://strat-talk.com/threads/fender-s1-super-switch-wiring-diagram.574879/post-5139061