### PR TITLE
Add 'M' and 'N' potentiometer taper options

### DIFF
--- a/diylc/diylc-library/src/main/java/org/diylc/components/passive/Taper.java
+++ b/diylc/diylc-library/src/main/java/org/diylc/components/passive/Taper.java
@@ -23,7 +23,7 @@ package org.diylc.components.passive;
 
 public enum Taper {
 
-  LIN, LOG, REV_LOG, W, S;
+  LIN, LOG, REV_LOG, W, S, M, N;
 
   @Override
   public String toString() {


### PR DESCRIPTION
Quite self-explanatory, added M and N as potentiometer taper options as found on blend pots.